### PR TITLE
Fix Dask CLI registration

### DIFF
--- a/dask_databricks/cli.py
+++ b/dask_databricks/cli.py
@@ -1,12 +1,12 @@
 import click
 
-@click.group
+@click.group(name="databricks")
 def main():
-    """Subcommands to launch Dask on Databricks."""
+    """Tools to launch Dask on Databricks."""
 
 @main.command()
 def run():
-    """Run a databricks cluster"""
+    """Run Dask processes on a Databricks cluster."""
     print("I am going to run a cluster.")
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `databricks` subcommand wasn't showing up. Turns out it was because the `click` group didn't have a name, and the default name of `main` was colliding with other registered subcommands.

This PR gives the group a name to match the subcommand and also tweaks the docstrings a little.