### PR TITLE
Add get_client utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,12 @@ To launch a Dask cluster on Databricks you need to create an [init script](https
 dask databricks run
 ```
 
-Then from your Databricks Notebook you can use the `DatabricksCluster` class to quickly connect a Dask `Client` to the scheduler running on the Spark Driver Node.
+Then from your Databricks Notebook you can quickly connect a Dask `Client` to the scheduler running on the Spark Driver Node.
 
 ```python
-from dask.distributed import Client
-from dask_databricks import DatabricksCluster
+import dask_databricks
 
-cluster = DatabricksCluster()
-client = Client(cluster)
+client = dask_databricks.get_client()
 ```
 
 Now you can submit work from your notebook to the multi-node Dask cluster.

--- a/dask_databricks/__init__.py
+++ b/dask_databricks/__init__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: BSD-3
 
-from .databrickscluster import DatabricksCluster
+from .databrickscluster import DatabricksCluster, get_client

--- a/dask_databricks/databrickscluster.py
+++ b/dask_databricks/databrickscluster.py
@@ -34,3 +34,7 @@ class DatabricksCluster(Cluster):
     async def _start(self):
         self.scheduler_comm = rpc(f'{self.spark_local_ip}:8786')
         await super()._start()
+
+def get_client():
+    """Get a Dask client connected to a Databricks cluster."""
+    return DatabricksCluster().get_client()

--- a/dask_databricks/tests/test_databricks.py
+++ b/dask_databricks/tests/test_databricks.py
@@ -5,7 +5,7 @@ from dask.distributed import Client
 from distributed.deploy import Cluster, LocalCluster
 
 
-from dask_databricks import DatabricksCluster
+from dask_databricks import DatabricksCluster, get_client
 
 @pytest.fixture(scope="session")
 def dask_cluster():
@@ -44,4 +44,11 @@ def test_databricks_cluster_create_client(set_spark_local_ip, dask_cluster):
     cluster = DatabricksCluster()
     client = Client(cluster)
     assert isinstance(client, Client)
+    assert client.submit(sum, (10, 1)).result() == 11
+
+
+def test_get_client(set_spark_local_ip, dask_cluster):
+    client = get_client()
+    assert isinstance(client, Client)
+    assert isinstance(client.cluster, DatabricksCluster)
     assert client.submit(sum, (10, 1)).result() == 11


### PR DESCRIPTION
Creating a `DatabricksCluster` class in #17 allows this project to fit nicely into the Dask ecosystem and provide APIs familiar to Dask users. It also allows us to integrate with other tools like `dask-ctl` in the future.

However, for most new user's they probably aren't interested in any of this, at least not right away. Given that the `DatabricksCluster` object doesn't need any configuration and grabs everything from the driver node environment it's easy to add a small utility that abstracts creating the cluster object and client away for some syntactic sugar.

```python
import dask_databricks

# Added in this PR
client = dask_databricks.get_client()

# which is equivalent to
client = dask_databricks.DatabricksCluster().get_client()

# which is also equivalent to
from dask.distributed import Client
cluster = dask_databricks.DatabricksCluster()
client = Client(cluster)
```

In all of these cases a reference to the cluster object is still available at `client.cluster` so users can do things like call `client.cluster.get_logs()` to retrieve scheduler and worker logs.