### PR TITLE
Bump minimum click to >=8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "click",
+  "click>=8.1",
   "dask",
   "rich",
   "distributed",


### PR DESCRIPTION
Quickly bumping the `click` minimum to work around the bug found in #20 so we don't have to wait for https://github.com/dask/dask/pull/10623