### PR TITLE
Set upper bound on bokeh to 3.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
+  "bokeh<=3.2.2",  # Necessary until https://github.com/dask/distributed/issues/8333 is resolved
   "click>=8.1",
   "dask",
   "rich",


### PR DESCRIPTION
The dashboard is broken with `bokeh>=3.3` due to some absolute URLs being set. This is being tracked in https://github.com/dask/distributed/issues/8333.

Pinning the upper bound here for now to give `dask-databricks` users a good experience.