### PR TITLE
Remove Dashboard port 8787

### DIFF
--- a/dask_databricks/cli.py
+++ b/dask_databricks/cli.py
@@ -48,7 +48,7 @@ def run(worker_command, worker_args, cuda):
 
     if DB_IS_DRIVER == "TRUE":
         log.info("This node is the Dask scheduler.")
-        scheduler_process = subprocess.Popen(["dask", "scheduler", "--dashboard-address", ":8787,:8087"])
+        scheduler_process = subprocess.Popen(["dask", "scheduler", "--dashboard-address", ":8087"])
         time.sleep(5)  # give the scheduler time to start
         if scheduler_process.poll() is not None:
             log.error("Scheduler process has exited prematurely.")


### PR DESCRIPTION
Databricks does not alow you to proxy services on port `8787`, so I added extra config to also run the Dashboard on `8087` so that we can access it.

It seems like the reason why we can't use `8787` is to avoid collisions with R Shiny. So this PR removes `8787` altogether and just leaves `8087`.